### PR TITLE
Enable spi0-m2-cs0,uart3-m1,pwm7-m3 in default dts on rock-5b-plus board

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
@@ -1281,3 +1281,29 @@
 		/* GPIO4_D4-D7 */
 		"", "", "", "";
 };
+
+&spi0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0m2_cs0 &spi0m2_pins>;
+	max-freq = <50000000>;
+
+	spidev@0 {
+		compatible = "rockchip,spidev";
+		status = "okay";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+	};
+};
+
+&uart3 {
+	status = "okay";
+	pinctrl-0 = <&uart3m1_xfer>;
+};
+
+&pwm7 {
+	status = "okay";
+	pinctrl-0 = <&pwm7m3_pins>;
+};


### PR DESCRIPTION
In the device tree file of the ROCK-5B-PLUS board, turn on the spi0-m2-cs0, uart3-m1, and pwm7-m3 peripheral interfaces to make it easier to use the output file compiled from this kernel to turn on these peripheral interfaces by default.